### PR TITLE
Subpath nodes returned as ids (str) not Nodes

### DIFF
--- a/pathpy/classes/edge.py
+++ b/pathpy/classes/edge.py
@@ -342,7 +342,7 @@ class Edge(object):
         --------
         Create new edge and get the weight.
 
-        >>> form pathpy import Edge
+        >>> from pathpy import Edge
         >>> vw = Edge('vw','v','w')
         >>> print(vw.weight())
 

--- a/pathpy/classes/path.py
+++ b/pathpy/classes/path.py
@@ -219,7 +219,7 @@ class Path(Network):
         --------
         Adding a singe new node to the network.
 
-        >>> form pathpy import Node, Path
+        >>> from pathpy import Node, Path
         >>> p = Path()
         >>> p.add_node('a',color='red')
 
@@ -617,11 +617,11 @@ class Path(Network):
 
         Examples
         --------
-        >>> form pathpy import Path
+        >>> from pathpy import Path
         >>> p = Path(['a','b','c','d','e'])
         >>> P = p.subpaths()
         >>> for q in P:
-        >>>     print(q.name)
+        ...     print(q.name)
         a-b
         b-c
         c-d

--- a/pathpy/tests/test_path.py
+++ b/pathpy/tests/test_path.py
@@ -171,6 +171,14 @@ def test_subpaths():
         assert p.subpaths(min_length=100, max_length=0)
 
 
+def test_subpath_names():
+    from pathpy import Path
+    p = Path(['a','b','c','d','e'])
+    P = p.subpaths()
+    for q in P:
+        breakpoint()
+        print(q.name)
+
 # =============================================================================
 # eof
 #


### PR DESCRIPTION
Hi @hackl, awesome work on the code-base I love it.

I have found that one of the tests does not pass, since in the doctest you assume that `path.subpaths()` returns a list of `Node` types but it returns a `str`. Both a perfectly find just wanted to know what the expected behaviour should be.

L